### PR TITLE
Make /plugins return a list of all plugins. Rename /plugin to /plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.idea/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/api/dev.Dockerfile
+++ b/api/dev.Dockerfile
@@ -1,0 +1,22 @@
+FROM dannixon/savu:latest
+
+# Install additional Python dependencies
+ADD requirements.txt \
+    /requirements.txt
+
+# Install project requirements, AND install pydevd - for remote debugging with PyCharm
+RUN /miniconda/bin/pip install -r /requirements.txt && \
+    rm /requirements.txt && /miniconda/bin/pip install pydevd
+
+# Copy API application configuration
+ADD ./config/dls.json \
+    /hebi_config.json
+
+# Expose API port
+EXPOSE 5000
+
+# Run server
+CMD ["/webservice/run.sh"]
+
+# Note: application files not added, they must be mounted
+# via `docker run` via `-v/--mount /development/source:/webservice`

--- a/api/readme.md
+++ b/api/readme.md
@@ -16,13 +16,13 @@ from each version of the Savu image that is desired.
 ### Plugin
 
 - List all plugins  
-  `GET /api/plugin`
+  `GET /api/plugins`
 
 - Search plugins by name  
-  `GET /api/plugin?q=tomo`
+  `GET /api/plugins?q=tomo`
 
 - List plugin details  
-  `GET /api/plugin/TomopyRecon`
+  `GET /api/plugins/TomopyRecon`
 
 ### Process list
 

--- a/api/webservice/const.py
+++ b/api/webservice/const.py
@@ -15,6 +15,7 @@ KEY_PROCESS_LIST_FILE = 'process_list'
 KEY_PLUGINS = 'plugins'
 KEY_QUERY = 'q'
 KEY_QUEUE_ID = 'queue'
+KEY_DETAILS = 'details'
 
 WS_NAMESPACE_JOB_STATUS = '/job_status'
 

--- a/api/webservice/server_test.py
+++ b/api/webservice/server_test.py
@@ -1,7 +1,8 @@
-import unittest
 import json
+import unittest
 
 import server
+import urls
 from utils import populate_plugins
 
 
@@ -24,25 +25,32 @@ class ServerTest(unittest.TestCase):
             },
         }
 
-    def test_get_plugin(self):
-        rv = self.app.get('/plugin')
+    def test_get_plugins(self):
+        rv = self.app.get(urls.PLUGINS)
         data = json.loads(rv.data)
 
         self.assertTrue(isinstance(data, list))
         self.assertGreater(len(data), 0)
 
+    def test_get_plugins_with_details(self):
+        rv = self.app.get("{}?details=true".format(urls.PLUGINS))
+        data = json.loads(rv.data)
+
+        self.assertTrue(isinstance(data, dict))
+        self.assertGreater(len(data.keys()), 0)
+
     def test_get_plugin_info_no_citation(self):
-        rv = self.app.get('/plugin/Dezinger')
+        rv = self.app.get('{}/Dezinger'.format(urls.PLUGINS))
         data = json.loads(rv.data)
         self.assertEqual(len(data['citation']), 0)
 
     def test_get_plugin_info_1_citation(self):
-        rv = self.app.get('/plugin/TomopyRecon')
+        rv = self.app.get('{}/TomopyRecon'.format(urls.PLUGINS))
         data = json.loads(rv.data)
         self.assertEqual(len(data['citation']), 1)
 
     def test_get_plugin_info_multiple_citation(self):
-        rv = self.app.get('/plugin/AstraReconGpu')
+        rv = self.app.get('{}/AstraReconGpu'.format(urls.PLUGINS))
         data = json.loads(rv.data)
         self.assertEqual(len(data['citation']), 3)
 

--- a/api/webservice/urls.py
+++ b/api/webservice/urls.py
@@ -1,0 +1,1 @@
+PLUGINS = "/plugins"

--- a/api/webservice/validation.py
+++ b/api/webservice/validation.py
@@ -1,6 +1,8 @@
-from voluptuous import Schema, Required, Optional, All, Any, Length, Number, Extra
+from voluptuous import Schema, Required, Optional, All, Any, Length, Extra, ALLOW_EXTRA
 
 _string = Any(str, unicode)
+
+_bool = Any(bool, unicode)
 
 _non_empty_string = All(_string, Length(min=1))
 
@@ -24,6 +26,7 @@ _parameter_full.update({
     Optional('type'): _non_empty_string,
     Required('is_user'): bool,
     Required('is_hidden'): bool,
+    Required('value'): Any()
 })
 
 _plugin_basic = {
@@ -62,8 +65,6 @@ server_configuration_schema = Schema({
     }
 })
 
-query_plugin_list_schema = Schema([_non_empty_string])
-
 get_plugin_info_schema = Schema({
     Required('name'): _non_empty_string,
     Required('info'): _string,
@@ -72,6 +73,12 @@ get_plugin_info_schema = Schema({
     Required('citation'): [_citation],
     Required('parameters'): [_parameter_full],
 })
+
+query_plugin_list_with_details_schema = Schema({
+    Required(_non_empty_string): get_plugin_info_schema
+}, extra=ALLOW_EXTRA)
+
+query_plugin_list_schema = Schema([_non_empty_string], extra=ALLOW_EXTRA)
 
 filename_listing_schema = Schema({
     Required('path'): _non_empty_string,

--- a/web/config/www/src/api_savu.js
+++ b/web/config/www/src/api_savu.js
@@ -1,13 +1,13 @@
 function getAvailablePlugins(callback, error) {
-  jsonGet("/api/plugin", callback, error);
+  jsonGet("/api/plugins", callback, error);
 }
 
 function searchAvailablePlugins(query, callback, error) {
-  jsonGet("/api/plugin?q=" + query, callback, error);
+  jsonGet("/api/plugins?q=" + query, callback, error);
 }
 
 function getPluginDetails(pluginName, callback, error) {
-  jsonGet("/api/plugin/" + pluginName, callback, error);
+  jsonGet("/api/plugins/" + pluginName, callback, error);
 }
 
 function getAvailableProcessLists(searchPath, callback, error) {


### PR DESCRIPTION
URL `/plugin` renamed to `/plugins` to conform with URLs returning collections' naming conventions.

Querying `/plugins` returns a list of all available plugins' names. Adding `?details=true` returns a dictionary with all plugins and details for each one.

Also adds a development Dockerfile, allowing the developer to manually mount a changing source (the development source) so as to not rebuild the docker image after each change. This installs `pydevd` for remote debugging.